### PR TITLE
Adapt serialization to revised protocol

### DIFF
--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -802,6 +802,9 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
     if (strcmp(name, "serialization_create") == 0) {
         strncpy(type, "uint64_t", BMI_MAX_TYPE_NAME);
         return BMI_SUCCESS;
+    } else if (strcmp(name, "serialization_size") == 0) {
+        strncpy(type, "uint64_t", BMI_MAX_TYPE_NAME);
+        return BMI_SUCCESS;
     } else if (strcmp(name, "serialization_state") == 0) {
         strncpy(type, "char", BMI_MAX_TYPE_NAME);
         return BMI_SUCCESS;
@@ -990,11 +993,12 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
     }
 
     // serialiation
-    if (strcmp(name, "serialization_create") == 0) {
-        if (new_serialized_pet(self) != BMI_SUCCESS) {
+    if (strcmp(name, "serialization_size") == 0) {
+        pet_model *pet = (pet_model *)self->data;
+        if (pet->serialized == NULL) {
+            // Log(SEVERE, "PET serialization has not been.");
             return BMI_FAILURE;
         }
-        pet_model *pet = (pet_model *)self->data;
         *dest = &pet->serialized_length;
         return BMI_SUCCESS;
     }
@@ -1056,13 +1060,12 @@ static int Get_value(Bmi * self, const char * name, void *dest)
 static int Set_value (Bmi *self, const char *name, void *array)
 {
     // special cases for serialization
-    if (strcmp(name, "serialization_state") == 0) {
+    if (strcmp(name, "serialization_create") == 0) {
+        return new_serialized_pet(self);
+    } else if (strcmp(name, "serialization_state") == 0) {
         return load_serialized_pet(self, (char*)array);
     } else if (strcmp(name, "serialization_free") == 0) {
         return free_serialized_pet(self);
-    } else if (strcmp(name, "serialization_create") == 0) {
-        // Log(WARNING, "Cannot use \"serialization_create\" to set a value.");
-        return BMI_FAILURE;
     }
 
     void * dest = NULL;
@@ -1171,7 +1174,7 @@ static int Get_var_units (Bmi *self, const char *name, char * units)
 static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
 {
     // special serialization messages
-    if (strcmp(name, "serialization_create") == 0) {
+    if (strcmp(name, "serialization_create") == 0 || strcmp(name, "serialization_size") == 0) {
         *nbytes = sizeof(uint64_t);
         return BMI_SUCCESS;
     } else if (strcmp(name, "serialization_state") == 0) {


### PR DESCRIPTION
The earlier BMI state saving protocol was not going to be tenable on Fortran due to intent(in) dummy arguments. This revision simplifies the protocol such that SetValue is used for mutating actions, and GetValue/GetValuePtr are used for queries.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: