### PR TITLE
Reset Time and Size Header (NGWPC-9779)

### DIFF
--- a/include/pet.h
+++ b/include/pet.h
@@ -220,11 +220,12 @@ struct pet_bmi
                But what if we want to run at a timestep different than seconds? 
                We probably would never do that. The output is in units of m_per_s, so this is probably good.
   */
-  int time_step_size_s;
   long int num_timesteps;
   double current_time_step;   // this is the actual time of the run.
   long int current_step;        // this is a sequential value to find the correct row from forcing file
   double current_time;        // this should be in "Seconds since 1970", so should be start time plus current time step
+  double starting_time;       // store the "current_time" value from the config for "reset_time" BMI option
+  int time_step_size_s;
   int verbose;
   int run_unit_tests;
   int is_forcing_from_bmi;

--- a/include/pet_serialization.h
+++ b/include/pet_serialization.h
@@ -9,7 +9,7 @@ extern "C" {
 
 int free_serialized_pet(Bmi* bmi);
 int new_serialized_pet(Bmi* bmi);
-int load_serialized_pet(Bmi* bmi, const char* data);
+int load_serialized_pet(Bmi* bmi, char* data);
 
 #ifdef __cplusplus
 }

--- a/include/vecbuf.hpp
+++ b/include/vecbuf.hpp
@@ -28,6 +28,9 @@ public:
     // Forwarder for std::vector::clear()
     constexpr void clear() { vector_.clear(); }
 
+    // Forwarder for std::vector::resize(size)
+    constexpr void resize(size_type size) { vector_.resize(size); }
+
     // Forwarder for std::vector::reserve
     constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
 
@@ -35,7 +38,7 @@ public:
     constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
 
     // Forwarder for std::vector::data
-    constexpr const value_type* data() const { return vector_.data(); }
+    constexpr value_type* data() { return vector_.data(); }
 
     // Forwarder for std::vector::size
     constexpr size_type size() const { return vector_.size(); }
@@ -110,6 +113,13 @@ private:
         return written;
     }
 
+};
+
+class membuf : public std::streambuf {
+public:
+    membuf(char *begin, size_t size) {
+        this->setg(begin, begin, begin + size);
+    }
 };
 
 #endif

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -1079,6 +1079,7 @@ static int Set_value (Bmi *self, const char *name, void *array)
         model->bmi.current_time_step = 0.0;
         // recover starting time from the config; doesn't seem to be used in processing
         model->bmi.current_time = model->bmi.starting_time;
+        return BMI_SUCCESS;
     }
 
     void * dest = NULL;

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -116,8 +116,10 @@ Initialize (Bmi *self, const char *cfg_file)
     
     
             pet->forcing_data_time[i] = forcings.time;
-            if (i == 0)
+            if (i == 0) {
                 pet->bmi.current_time =forcings.time;
+                pet->bmi.starting_time = forcings.time;
+            }
         }
         fclose(ffp);
     }
@@ -811,6 +813,9 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
     } else if (strcmp(name, "serialization_free") == 0) {
         strncpy(type, "int", BMI_MAX_TYPE_NAME);
         return BMI_SUCCESS;
+    } else if (strcmp(name, "reset_time") == 0) {
+        strncpy(type, "double", BMI_MAX_TYPE_NAME);
+        return BMI_SUCCESS;
     }
     // Check to see if in output array first
     for (int i = 0; i < OUTPUT_VAR_NAME_COUNT; i++) {
@@ -1066,6 +1071,14 @@ static int Set_value (Bmi *self, const char *name, void *array)
         return load_serialized_pet(self, (char*)array);
     } else if (strcmp(name, "serialization_free") == 0) {
         return free_serialized_pet(self);
+    } else if (strcmp(name, "reset_time") == 0) {
+        pet_model *model = (pet_model *)self->data;
+        // set to 0 in init; used in indexing into forcing data
+        model->bmi.current_step = 0;
+        // just used in reporting
+        model->bmi.current_time_step = 0.0;
+        // recover starting time from the config; doesn't seem to be used in processing
+        model->bmi.current_time = model->bmi.starting_time;
     }
 
     void * dest = NULL;
@@ -1183,6 +1196,9 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
         return BMI_SUCCESS;
     } else if (strcmp(name, "serialization_free") == 0) {
         *nbytes = sizeof(int);
+        return BMI_SUCCESS;
+    } else if (strcmp(name, "reset_time") == 0) {
+        *nbytes = sizeof(double);
         return BMI_SUCCESS;
     }
     int item_size;

--- a/src/pet_serialization.cpp
+++ b/src/pet_serialization.cpp
@@ -114,7 +114,8 @@ int new_serialized_pet(Bmi* bmi) {
         free(model->serialized);
     }
     // set size and allocate memory
-    model->serialized_length = stream.size();
+    uint64_t serialized_size = stream.size();
+    model->serialized_length = serialized_size + sizeof(uint64_t);
     model->serialized = (char*)malloc(model->serialized_length);
     // make sure memory could be allocated
     if (model->serialized == NULL) {
@@ -122,14 +123,17 @@ int new_serialized_pet(Bmi* bmi) {
         model->serialized_length = 0;
         return BMI_FAILURE;
     }
-    // copy stream data to new allocation
-    memcpy(model->serialized, stream.data(), model->serialized_length);
+    // copy size of stream data and stream data to new allocation
+    memcpy(model->serialized, &serialized_size, sizeof(uint64_t));
+    memcpy(model->serialized + sizeof(uint64_t), stream.data(), serialized_size);
     return BMI_SUCCESS;
 }
 
-int load_serialized_pet(Bmi* bmi, const char* data) {
+int load_serialized_pet(Bmi* bmi, char* data) {
     BmiPetSerialization serializer(bmi);
-    std::istringstream stream(data);
+    uint64_t size;
+    memcpy(&size, data, sizeof(uint64_t));
+    membuf stream(data + sizeof(uint64_t), size);
     boost::archive::binary_iarchive archive(stream);
     try {
         archive >> serializer;

--- a/src/pet_serialization.cpp
+++ b/src/pet_serialization.cpp
@@ -74,7 +74,6 @@ serialize(Archive& ar, const unsigned int version) {
     ar & model->inter_vars.moist_air_gas_constant_J_per_kg_K;
     ar & model->inter_vars.moist_air_density_kg_per_m3;
     ar & model->inter_vars.slope_sat_vap_press_curve_Pa_s;
-    ar & model->inter_vars.water_latent_heat_of_vaporization_J_per_kg;
     ar & model->inter_vars.psychrometric_constant_Pa_per_C;
 
     // surface radiation forcing


### PR DESCRIPTION
The PR seeks to address two issues related to serialization:
1) A message for resetting the BMI's current time to 0 that will be used after loading a state from save state at the start of processing.
2) Convert the deserialization object from `stringstream` to a sized object. `stringstream` would compile, but boost will throw a runtime error if the incoming data is not sized.

## Additions

- Add size header to serialized data.
- Ability to set the value `"reset_time"` to set the BMI's current time to 0. This is recognized as type `double` for the purpose of messaging but cannot be used for anything other than setting it with the source data going unused.

## Removals

- Duplicate serialization of property `water_latent_heat_of_vaporization_J_per_kg`

## Changes

-

## Testing

1. Successfully run state saving and loading using the NGEN `philmiller-8996-state-saving-api` branch.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
