### PR TITLE
Remove using generic EWTS_ID

### DIFF
--- a/include/logger.h
+++ b/include/logger.h
@@ -1,7 +1,13 @@
 #ifndef PET_LOGGER_H
 #define PET_LOGGER_H
+
 #include "ewts/module_constants.h"
-#define EWTS_ID EWTS_ID_PET
 #include "ewts/logger.h"
 #include "ewts/log_levels.h"
+
+#define Log(level, ...) EwtsLogModule(EWTS_ID_PET, (level), __VA_ARGS__)
+#define LOG(level, ...) EwtsLogModule(EWTS_ID_PET, (level), __VA_ARGS__)
+#define GetLogLevel() EwtsGetLogLevelModule(EWTS_ID_PET)
+#define IsLoggingEnabled() EwtsIsLoggingEnabledModule(EWTS_ID_PET)
+
 #endif /* PET_LOGGER_H */


### PR DESCRIPTION
Remove using generic EWTS_ID causing log messages to be incorrectly identified in the logs.