### PR TITLE
Exclude or include or EWTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(petbmi PRIVATE ewts::ewts_c)
 
 # Built with ngen bridge
 target_link_libraries(petbmi PRIVATE ewts::ewts_ngen_bridge)
-target_compile_definitions(petbmi PRIVATE EWTS_HAVE_NGEN_BRIDGE)
+target_compile_definitions(petbmi PRIVATE USE_EWTS)
 
 # Code requires minimum of C99 standard to compile
 set_target_properties(petbmi PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,15 +34,23 @@ set_target_properties(petbmi PROPERTIES PUBLIC_HEADER include/bmi_pet.h)
 
 target_link_libraries(petbmi PRIVATE Boost::serialization)
 
-# --- EWTS (installed from nwm-ewts) ---
-find_package(ewts CONFIG REQUIRED)
+option(USE_EWTS "Build PET with EWTS logging" ON)
+message("-- PET CMakeLists USE_EWTS = ${USE_EWTS}")
+if(USE_EWTS)
+    message("-- PET compiled with EWTS logging")
 
-# Always use EWTS runtime logger for C
-target_link_libraries(petbmi PRIVATE ewts::ewts_c)
+    # --- EWTS (installed from nwm-ewts) ---
+    find_package(ewts CONFIG REQUIRED)
 
-# Built with ngen bridge
-target_link_libraries(petbmi PRIVATE ewts::ewts_ngen_bridge)
-target_compile_definitions(petbmi PRIVATE USE_EWTS)
+    # Always use EWTS runtime logger for C
+    target_link_libraries(petbmi PRIVATE ewts::ewts_c)
+
+    # Built with ngen bridge
+    target_link_libraries(petbmi PRIVATE ewts::ewts_ngen_bridge)
+    target_compile_definitions(petbmi PRIVATE PET_USE_EWTS)
+else()
+    message("-- PET compiled with stdout fallback logging")
+endif()
 
 # Code requires minimum of C99 standard to compile
 set_target_properties(petbmi PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED ON)

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,13 +1,119 @@
 #ifndef PET_LOGGER_H
 #define PET_LOGGER_H
 
+#ifdef PET_USE_EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Using EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
 #include "ewts/module_constants.h"
 #include "ewts/logger.h"
 #include "ewts/log_levels.h"
 
-#define Log(level, ...) EwtsLogModule(EWTS_ID_PET, (level), __VA_ARGS__)
-#define LOG(level, ...) EwtsLogModule(EWTS_ID_PET, (level), __VA_ARGS__)
-#define GetLogLevel() EwtsGetLogLevelModule(EWTS_ID_PET)
-#define IsLoggingEnabled() EwtsIsLoggingEnabledModule(EWTS_ID_PET)
+#define PET_MODULE_ID EWTS_ID_PET
 
+#define Log(level, ...) EwtsLogModule(PET_MODULE_ID, (level), __VA_ARGS__)
+#define LOG(level, ...) EwtsLogModule(PET_MODULE_ID, (level), __VA_ARGS__)
+#define GetLogLevel() EwtsGetLogLevelModule(PET_MODULE_ID)
+#define IsLoggingEnabled() EwtsIsLoggingEnabledModule(PET_MODULE_ID)
+
+#else
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Log messages written to STDOUT
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define PET_MODULE_ID "PET"
+typedef enum {
+    NOTSET  = 0,
+    DEBUG   = 10,
+    PERFORM = 15,
+    INFO    = 20,
+    WARNING = 30,
+    SEVERE  = 40,
+    FATAL   = 50
+} LogLevel;
+
+#define PET_FALLBACK_LOGGING_ENABLED   1
+#define PET_FALLBACK_LOG_LEVEL         INFO
+
+static inline bool IsLoggingEnabled(void) {
+    return PET_FALLBACK_LOGGING_ENABLED;
+}
+
+static inline LogLevel GetLogLevel(void) {
+    return PET_FALLBACK_LOG_LEVEL;
+}
+
+static inline const char* pet_level_to_string(LogLevel level) {
+    switch (level) {
+        case DEBUG:   return "DEBUG";
+        case PERFORM: return "PERFORM";
+        case INFO:    return "INFO";
+        case WARNING: return "WARN";
+        case SEVERE:  return "ERROR";
+        case FATAL:   return "FATAL";
+        default:      return "LOG";
+    }
+}
+
+static inline void pet_utc_timestamp(char* buffer, size_t size) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+
+    struct tm tm_utc;
+    gmtime_r(&tv.tv_sec, &tm_utc);
+
+    char base[32];
+    strftime(base, sizeof(base), "%Y-%m-%dT%H:%M:%S", &tm_utc);
+
+    snprintf(buffer, size, "%s.%03ldZ", base, tv.tv_usec / 1000);
+}
+
+static inline void pet_strip_trailing_newlines(char* s) {
+    if (!s) return;
+
+    size_t len = strlen(s);
+    while (len > 0 && (s[len - 1] == '\n' || s[len - 1] == '\r')) {
+        s[--len] = '\0';
+    }
+}
+
+static inline void Log(LogLevel level, const char* fmt, ...) {
+    if (!fmt) return;
+    if (!IsLoggingEnabled()) return;
+    if (level < GetLogLevel()) return;
+
+    char message[4096];
+
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(message, sizeof(message), fmt, args);
+    va_end(args);
+
+    pet_strip_trailing_newlines(message);
+
+    char timestamp[64];
+    pet_utc_timestamp(timestamp, sizeof(timestamp));
+
+    char line[8192];
+    snprintf(line, sizeof(line), "%s %s %s %s\n",
+             timestamp,
+             PET_MODULE_ID,
+             pet_level_to_string(level),
+             message);
+
+    fputs(line, stdout);
+    fflush(stdout);
+}
+
+#define LOG(level, ...) Log((level), __VA_ARGS__)
+#endif
 #endif /* PET_LOGGER_H */

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -19,11 +19,13 @@ static int
 Initialize (Bmi *self, const char *cfg_file)
 {
 
-    #ifdef USE_EWTS
-        EwtsInit(EWTS_ID_PET, true);
-    #else
-        EwtsInit(EWTS_ID_PET, false);
-    #endif
+#ifdef PET_USE_EWTS
+    // Initialize the Error and Warning Trapping System
+    #pragma message("evapotranspiration.bmi_pet.Initialize: PET_USE_EWTS ON")
+    EwtsInit(PET_MODULE_ID, true);
+#else
+    #pragma message("evapotranspiration.bmi_pet.Initialize: PET_USE_EWTS OFF")
+#endif
 
     if (self == NULL || self->data == NULL) {
         LOG(FATAL, "Initialize failed: self or self->data is NULL");

--- a/src/bmi_pet.c
+++ b/src/bmi_pet.c
@@ -19,7 +19,7 @@ static int
 Initialize (Bmi *self, const char *cfg_file)
 {
 
-    #ifdef EWTS_HAVE_NGEN_BRIDGE
+    #ifdef USE_EWTS
         EwtsInit(EWTS_ID_PET, true);
     #else
         EwtsInit(EWTS_ID_PET, false);

--- a/src/main_pass_forcing.c
+++ b/src/main_pass_forcing.c
@@ -94,11 +94,13 @@ void pass_forcing_from_aorc_to_pet(Bmi *pet_bmi_model, Bmi *aorc_bmi_model)
 int main(int argc, const char *argv[])
 {
 
-    #ifdef USE_EWTS
-        EwtsInit(EWTS_ID_PET, true);
-    #else
-        EwtsInit(EWTS_ID_PET, false);
-    #endif
+#ifdef PET_USE_EWTS
+    // Initialize the Error and Warning Trapping System
+    #pragma message("evapotranspiration.main_pass_forcing.main: PET_USE_EWTS ON")
+    EwtsInit(PET_MODULE_ID, true);
+#else
+    #pragma message("evapotranspiration.main_pass_forcing.main: PET_USE_EWTS OFF")
+#endif
 
     if (argc <= 1) {
         LOG(FATAL, "Missing PET config file argument");

--- a/src/main_pass_forcing.c
+++ b/src/main_pass_forcing.c
@@ -94,7 +94,7 @@ void pass_forcing_from_aorc_to_pet(Bmi *pet_bmi_model, Bmi *aorc_bmi_model)
 int main(int argc, const char *argv[])
 {
 
-    #ifdef EWTS_HAVE_NGEN_BRIDGE
+    #ifdef USE_EWTS
         EwtsInit(EWTS_ID_PET, true);
     #else
         EwtsInit(EWTS_ID_PET, false);

--- a/src/main_read_forcing.c
+++ b/src/main_read_forcing.c
@@ -14,7 +14,7 @@
 int main(int argc, const char *argv[])
 {
 
-    #ifdef EWTS_HAVE_NGEN_BRIDGE
+    #ifdef USE_EWTS
         EwtsInit(EWTS_ID_PET, true);
     #else
         EwtsInit(EWTS_ID_PET, false);

--- a/src/main_read_forcing.c
+++ b/src/main_read_forcing.c
@@ -14,11 +14,13 @@
 int main(int argc, const char *argv[])
 {
 
-    #ifdef USE_EWTS
-        EwtsInit(EWTS_ID_PET, true);
-    #else
-        EwtsInit(EWTS_ID_PET, false);
-    #endif
+#ifdef PET_USE_EWTS
+    // Initialize the Error and Warning Trapping System
+    #pragma message("evapotranspiration.main_read_forcing.main: PET_USE_EWTS ON")
+    EwtsInit(PET_MODULE_ID, true);
+#else
+    #pragma message("evapotranspiration.main_read_forcing.main: PET_USE_EWTS OFF")
+#endif
 
     if (argc <= 1) {
         LOG(FATAL, "Missing PET config file argument");

--- a/src/pet.c
+++ b/src/pet.c
@@ -70,7 +70,7 @@ extern void free_pet_model(pet_model *model) {
 extern int run_pet(pet_model* model)
 {
 
-  #ifdef EWTS_HAVE_NGEN_BRIDGE
+  #ifdef USE_EWTS
     EwtsInit(EWTS_ID_PET, true);
   #else
     EwtsInit(EWTS_ID_PET, false);

--- a/src/pet.c
+++ b/src/pet.c
@@ -70,11 +70,13 @@ extern void free_pet_model(pet_model *model) {
 extern int run_pet(pet_model* model)
 {
 
-  #ifdef USE_EWTS
-    EwtsInit(EWTS_ID_PET, true);
-  #else
-    EwtsInit(EWTS_ID_PET, false);
-  #endif
+#ifdef PET_USE_EWTS
+    // Initialize the Error and Warning Trapping System
+    #pragma message("evapotranspiration.pet.run_pet: PET_USE_EWTS ON")
+    EwtsInit(PET_MODULE_ID, true);
+#else
+    #pragma message("evapotranspiration.pet.run_pet: PET_USE_EWTS OFF")
+#endif
 
   if (model == NULL) {
     LOG(FATAL, "run_pet called with NULL model");


### PR DESCRIPTION
Exclude ewts when `PET_USE_EWTS` preprocessor symbol is not defined. This symbol is set in the `CMakeFiles.tx`t based on the `USE_EWTS` symbol.

## Additions

- Added check for `PET_USE_EWTS`. When defined, include the ewts library and initialize the ewts logger, otherwise fallback to stdout logging

## Removals

- Initializing the ewts logger when `USE_EWTS` is not defined. Log messages will be sent to stdout

## Testing

1. Tested with docker build command build argument `USE_EWTS` set `ON` 
2. Tested with docker build command build argument `USE_EWTS` set `OFF`
3. Tested with docker build command build argument `USE_EWTS` not set, which defaults to `ON`